### PR TITLE
Fix Range header exception

### DIFF
--- a/PartialZip/Services/HttpService.cs
+++ b/PartialZip/Services/HttpService.cs
@@ -51,7 +51,7 @@ namespace PartialZip.Services
                 HttpWebRequest request = WebRequest.CreateHttp(this._url);
                 request.AllowAutoRedirect = true;
                 request.KeepAlive = true;
-                request.Headers.Add("Range", $"bytes={startBytes}-{endBytes}");
+                request.AddRange((long)startBytes, (long)endBytes);
                 request.Method = "GET";
 
                 using (WebResponse response = await request.GetResponseAsync())


### PR DESCRIPTION
This lib is awesome, however I couldn't use it as is due to the following exception being thrown:
`System.ArgumentException: The 'Range' header must be modified using the appropriate property or method.`
I changed the function that sets `Range` to `AddRange()` instead and it started working for me. Had to convert ulong into long though since that function requires a long.