### PR TITLE
Add PartialZipSession for reusable archive access.

### DIFF
--- a/PartialZip/PartialZipDownloader.cs
+++ b/PartialZip/PartialZipDownloader.cs
@@ -1,30 +1,10 @@
-﻿using PartialZip.Exceptions;
-using PartialZip.Models;
-using PartialZip.Services;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace PartialZip
 {
     public class PartialZipDownloader
     {
-        private string _archiveUrl;
-
-        private HttpService _httpService;
-        private DeflateService _deflateService;
-
-        private PartialZipDownloader(string archiveUrl)
-        {
-            this._archiveUrl = archiveUrl;
-
-            this._httpService = new HttpService(this._archiveUrl);
-            this._deflateService = new DeflateService();
-        }
-
         /// <summary>
         /// Returns a list of all filenames in the remote .zip archive
         /// </summary>
@@ -32,10 +12,10 @@ namespace PartialZip
         /// <returns>List of filenames</returns>
         public static async Task<IEnumerable<string>> GetFileList(string archiveUrl)
         {
-            PartialZipDownloader downloader = new PartialZipDownloader(archiveUrl);
-            PartialZipInfo info = await downloader.Open();
+            PartialZipSession downloader = new PartialZipSession(archiveUrl);
+            await downloader.Open();
 
-            return info.CentralDirectory.Select(cd => cd.FileName).OrderBy(f => f);
+            return downloader.GetFileList();
         }
 
         /// <summary>
@@ -46,78 +26,11 @@ namespace PartialZip
         /// <returns>File content</returns>
         public static async Task<byte[]> DownloadFile(string archiveUrl, string filePath)
         {
-            PartialZipDownloader downloader = new PartialZipDownloader(archiveUrl);
-            PartialZipInfo info = await downloader.Open();
-            byte[] content = await downloader.Download(info, filePath);
+            PartialZipSession downloader = new PartialZipSession(archiveUrl);
+            await downloader.Open();
+            byte[] content = await downloader.DownloadFile(filePath);
 
             return content;
-        }
-
-        private async Task<PartialZipInfo> Open()
-        {
-            bool supportsPartialZip = await this._httpService.SupportsPartialZip();
-
-            if (!supportsPartialZip)
-                throw new PartialZipNotSupportedException("The web server does not support PartialZip as byte ranges are not accepted.");
-
-            PartialZipInfo info = new PartialZipInfo();
-
-            info.Length = await this._httpService.GetContentLength();
-
-            byte[] eocdBuffer = await this._httpService.GetRange(info.Length - EndOfCentralDirectory.Size, info.Length - 1);
-            info.EndOfCentralDirectory = new EndOfCentralDirectory(eocdBuffer);
-
-            ulong startCD, endCD;
-
-            if(info.EndOfCentralDirectory.IsZip64)
-            {
-                byte[] eocdLocator64Buffer = await this._httpService.GetRange(info.Length - EndOfCentralDirectory.Size - EndOfCentralDirectoryLocator64.Size, info.Length - EndOfCentralDirectory.Size);
-                info.EndOfCentralDirectoryLocator64 = new EndOfCentralDirectoryLocator64(eocdLocator64Buffer);
-
-                byte[] eocd64Buffer = await this._httpService.GetRange(info.EndOfCentralDirectoryLocator64.EndOfCentralDirectory64StartOffset, info.EndOfCentralDirectoryLocator64.EndOfCentralDirectory64StartOffset + EndOfCentralDirectory64.Size - 1);
-                info.EndOfCentralDirectory64 = new EndOfCentralDirectory64(eocd64Buffer);
-
-                (startCD, endCD) = (info.EndOfCentralDirectory64.CentralDirectoryStartOffset, info.EndOfCentralDirectory64.CentralDirectoryStartOffset + info.EndOfCentralDirectory64.CentralDirectorySize + EndOfCentralDirectory64.Size - 1);
-                info.CentralDirectoryEntries = info.EndOfCentralDirectory64.CentralDirectoryRecordCount;
-            }
-            else
-            {
-                (startCD, endCD) = (info.EndOfCentralDirectory.CentralDirectoryStartOffset, info.EndOfCentralDirectory.CentralDirectoryStartOffset + info.EndOfCentralDirectory.CentralDirectorySize + EndOfCentralDirectory.Size - 1);
-                info.CentralDirectoryEntries = info.EndOfCentralDirectory.CentralDirectoryRecordCount;
-            }
-
-            byte[] cdBuffer = await this._httpService.GetRange(startCD, endCD);
-            info.CentralDirectory = CentralDirectoryHeader.GetFromBuffer(cdBuffer, info.CentralDirectoryEntries);
-
-            return info;
-        }
-
-        private async Task<byte[]> Download(PartialZipInfo info, string filePath)
-        {
-            CentralDirectoryHeader cd = info.CentralDirectory.FirstOrDefault(c => c.FileName == filePath);
-
-            if(cd != null)
-            {
-                (ulong uncompressedSize, ulong compressedSize, ulong headerOffset, uint diskNum) = cd.GetFileInfo();
-
-                byte[] localFileBuffer = await this._httpService.GetRange(headerOffset, headerOffset + LocalFileHeader.Size - 1);
-                LocalFileHeader localFileHeader = new LocalFileHeader(localFileBuffer);
-
-                ulong start = headerOffset + LocalFileHeader.Size + localFileHeader.FileNameLength + localFileHeader.ExtraFieldLength;
-                byte[] compressedContent = await this._httpService.GetRange(start, start + compressedSize - 1);
-
-                switch(localFileHeader.Compression)
-                {
-                    case 0:
-                        return compressedContent;
-                    case 8:
-                        return this._deflateService.Inflate(compressedContent);
-                    default:
-                        throw new PartialZipUnsupportedCompressionException("Unknown compression.");
-                }
-            }
-
-            throw new PartialZipFileNotFoundException($"Could not find file {filePath} in archive.");
         }
     }
 }

--- a/PartialZip/PartialZipSession.cs
+++ b/PartialZip/PartialZipSession.cs
@@ -48,6 +48,24 @@ namespace PartialZip
         }
 
         /// <summary>
+        /// Returns a list of all ZipEntries in the remote .zip archive
+        /// </summary>
+        /// <returns>List of ZipEntries</returns>
+        public IEnumerable<ZipEntry> GetZipEntryList()
+        {
+            if (!_isOpen)
+                throw new InvalidOperationException("The archive must be opened before getting the entries list. Call Open() first.");
+
+            return _info.CentralDirectory.Select(cd => new ZipEntry
+            {
+                FileName = cd.FileName,
+                CompressedSize = ZipEntry.FormatSize(cd.CompressedSize),
+                UncompressedSize = ZipEntry.FormatSize(cd.UncompressedSize),
+                LastModified = ZipEntry.DosDateTimeToDateTime(cd.ModifiedDate, cd.ModifiedTime).ToString()
+            }).OrderBy(ze => ze.FileName);
+        }
+
+        /// <summary>
         /// Downloads a specific file from a remote .zip archive
         /// </summary>
         /// <param name="filePath">Path of the file</param>

--- a/PartialZip/PartialZipSession.cs
+++ b/PartialZip/PartialZipSession.cs
@@ -3,9 +3,7 @@ using PartialZip.Models;
 using PartialZip.Services;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 
 namespace PartialZip

--- a/PartialZip/PartialZipSession.cs
+++ b/PartialZip/PartialZipSession.cs
@@ -1,0 +1,133 @@
+﻿using PartialZip.Exceptions;
+using PartialZip.Models;
+using PartialZip.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace PartialZip
+{
+    public class PartialZipSession
+    {
+        private string _archiveUrl;
+
+        private HttpService _httpService;
+        private DeflateService _deflateService;
+
+        private PartialZipInfo info;
+        private bool _isOpen = false;
+
+        public PartialZipSession(string archiveUrl)
+        {
+            this._archiveUrl = archiveUrl;
+
+            this._httpService = new HttpService(this._archiveUrl);
+            this._deflateService = new DeflateService();
+        }
+
+        /// <summary>
+        /// Opens the archive and reads its structure.
+        /// </summary>
+        public async Task Open()
+        {
+            info = await PrivateOpen();
+            _isOpen = true;
+        }
+
+        /// <summary>
+        /// Returns a list of all filenames in the remote .zip archive
+        /// </summary>
+        /// <returns>List of filenames</returns>
+        public IEnumerable<string> GetFileList()
+        {
+            if (!_isOpen)
+                throw new InvalidOperationException("The archive must be opened before getting the file list. Call Open() first.");
+
+            return info.CentralDirectory.Select(cd => cd.FileName).OrderBy(f => f);
+        }
+
+        /// <summary>
+        /// Downloads a specific file from a remote .zip archive
+        /// </summary>
+        /// <param name="filePath">Path of the file</param>
+        /// <returns>File content</returns>
+        public async Task<byte[]> DownloadFile(string filePath)
+        {
+            if (!_isOpen)
+                throw new InvalidOperationException("The archive must be opened before downloading files. Call Open() first.");
+
+            byte[] content = await Download(info, filePath);
+            return content;
+        }
+
+        private async Task<PartialZipInfo> PrivateOpen()
+        {
+            bool supportsPartialZip = await this._httpService.SupportsPartialZip();
+
+            if (!supportsPartialZip)
+                throw new PartialZipNotSupportedException("The web server does not support PartialZip as byte ranges are not accepted.");
+
+            PartialZipInfo info = new PartialZipInfo();
+
+            info.Length = await this._httpService.GetContentLength();
+
+            byte[] eocdBuffer = await this._httpService.GetRange(info.Length - EndOfCentralDirectory.Size, info.Length - 1);
+            info.EndOfCentralDirectory = new EndOfCentralDirectory(eocdBuffer);
+
+            ulong startCD, endCD;
+
+            if (info.EndOfCentralDirectory.IsZip64)
+            {
+                byte[] eocdLocator64Buffer = await this._httpService.GetRange(info.Length - EndOfCentralDirectory.Size - EndOfCentralDirectoryLocator64.Size, info.Length - EndOfCentralDirectory.Size);
+                info.EndOfCentralDirectoryLocator64 = new EndOfCentralDirectoryLocator64(eocdLocator64Buffer);
+
+                byte[] eocd64Buffer = await this._httpService.GetRange(info.EndOfCentralDirectoryLocator64.EndOfCentralDirectory64StartOffset, info.EndOfCentralDirectoryLocator64.EndOfCentralDirectory64StartOffset + EndOfCentralDirectory64.Size - 1);
+                info.EndOfCentralDirectory64 = new EndOfCentralDirectory64(eocd64Buffer);
+
+                (startCD, endCD) = (info.EndOfCentralDirectory64.CentralDirectoryStartOffset, info.EndOfCentralDirectory64.CentralDirectoryStartOffset + info.EndOfCentralDirectory64.CentralDirectorySize + EndOfCentralDirectory64.Size - 1);
+                info.CentralDirectoryEntries = info.EndOfCentralDirectory64.CentralDirectoryRecordCount;
+            }
+            else
+            {
+                (startCD, endCD) = (info.EndOfCentralDirectory.CentralDirectoryStartOffset, info.EndOfCentralDirectory.CentralDirectoryStartOffset + info.EndOfCentralDirectory.CentralDirectorySize + EndOfCentralDirectory.Size - 1);
+                info.CentralDirectoryEntries = info.EndOfCentralDirectory.CentralDirectoryRecordCount;
+            }
+
+            byte[] cdBuffer = await this._httpService.GetRange(startCD, endCD);
+            info.CentralDirectory = CentralDirectoryHeader.GetFromBuffer(cdBuffer, info.CentralDirectoryEntries);
+
+            return info;
+        }
+
+        private async Task<byte[]> Download(PartialZipInfo info, string filePath)
+        {
+            CentralDirectoryHeader cd = info.CentralDirectory.FirstOrDefault(c => c.FileName == filePath);
+
+            if (cd != null)
+            {
+                (ulong uncompressedSize, ulong compressedSize, ulong headerOffset, uint diskNum) = cd.GetFileInfo();
+
+                byte[] localFileBuffer = await this._httpService.GetRange(headerOffset, headerOffset + LocalFileHeader.Size - 1);
+                LocalFileHeader localFileHeader = new LocalFileHeader(localFileBuffer);
+
+                ulong start = headerOffset + LocalFileHeader.Size + localFileHeader.FileNameLength + localFileHeader.ExtraFieldLength;
+                byte[] compressedContent = await this._httpService.GetRange(start, start + compressedSize - 1);
+
+                switch (localFileHeader.Compression)
+                {
+                    case 0:
+                        return compressedContent;
+                    case 8:
+                        return this._deflateService.Inflate(compressedContent);
+                    default:
+                        throw new PartialZipUnsupportedCompressionException("Unknown compression.");
+                }
+            }
+
+            throw new PartialZipFileNotFoundException($"Could not find file {filePath} in archive.");
+        }
+    }
+}

--- a/PartialZip/PartialZipSession.cs
+++ b/PartialZip/PartialZipSession.cs
@@ -17,7 +17,7 @@ namespace PartialZip
         private HttpService _httpService;
         private DeflateService _deflateService;
 
-        private PartialZipInfo info;
+        private PartialZipInfo _info;
         private bool _isOpen = false;
 
         public PartialZipSession(string archiveUrl)
@@ -33,7 +33,7 @@ namespace PartialZip
         /// </summary>
         public async Task Open()
         {
-            info = await PrivateOpen();
+            _info = await PrivateOpen();
             _isOpen = true;
         }
 
@@ -46,7 +46,7 @@ namespace PartialZip
             if (!_isOpen)
                 throw new InvalidOperationException("The archive must be opened before getting the file list. Call Open() first.");
 
-            return info.CentralDirectory.Select(cd => cd.FileName).OrderBy(f => f);
+            return _info.CentralDirectory.Select(cd => cd.FileName).OrderBy(f => f);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace PartialZip
             if (!_isOpen)
                 throw new InvalidOperationException("The archive must be opened before downloading files. Call Open() first.");
 
-            byte[] content = await Download(info, filePath);
+            byte[] content = await Download(_info, filePath);
             return content;
         }
 

--- a/PartialZip/ViewModels/ZipEntry.cs
+++ b/PartialZip/ViewModels/ZipEntry.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace PartialZip
+{
+    public class ZipEntry
+    {
+        public string FileName { get; set; }
+
+        public string CompressedSize { get; set; }
+
+        public string UncompressedSize { get; set; }
+
+        public string LastModified { get; set; }
+
+        public static DateTime DosDateTimeToDateTime(ushort date, ushort time)
+        {
+            int year = ((date >> 9) & 0x7F) + 1980;
+            int month = (date >> 5) & 0x0F;
+            int day = date & 0x1F;
+
+            int hour = (time >> 11) & 0x1F;
+            int minute = (time >> 5) & 0x3F;
+            int second = (time & 0x1F) * 2;
+
+            try
+            {
+                return new DateTime(year, month, day, hour, minute, second);
+            }
+            catch
+            {
+                return DateTime.MinValue;
+            }
+        }
+
+        public static string FormatSize(uint bytes)
+        {
+            string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+            double len = bytes;
+            int order = 0;
+            while (len >= 1024 && order < sizes.Length - 1)
+            {
+                order++;
+                len /= 1024;
+            }
+            return $"{len:0.##} {sizes[order]}";
+        }
+
+    }
+}


### PR DESCRIPTION
Added `PartialZipSession` class, a modified version of `PartialZipDownloader`.
It allows opening a remote ZIP archive once, listing files, and downloading specific entries manually.

Added `GetZipEntryList` method to return a detailed list of entries with metadata.

Introduced a `ZipEntry` view model to represent file information in a clean and structured way.

### Example usage:

```csharp
PartialZipSession downloader = new PartialZipSession(archiveUrl);
await downloader.Open();
var fileList = downloader.GetZipEntryList().ToArray();
byte[] fileContent = await downloader.DownloadFile(fileList[0].FileName);
